### PR TITLE
Enable support for STM32U585

### DIFF
--- a/IDE/STM32Cube/wolfssl_example.c
+++ b/IDE/STM32Cube/wolfssl_example.c
@@ -107,7 +107,9 @@
 
 /* This sets which UART to use for the console.  It is something you will have
  * to configure in STMCubeIDE and then change here. */
+#ifndef HAL_CONSOLE_UART
 #define HAL_CONSOLE_UART huart3
+#endif
 extern UART_HandleTypeDef HAL_CONSOLE_UART;
 
 /*****************************************************************************


### PR DESCRIPTION
* add a client and server over UART command using DMA.
* use kyber level 1 if HAVE_PQC is defined.
* only call TLSX_UseSupportedCurve() for kyber level 1.
* make sure only one of HAVE_LIBOQS or HAVE_PQM4 is defined.